### PR TITLE
Auto set project uv

### DIFF
--- a/figura-format.js
+++ b/figura-format.js
@@ -1,6 +1,27 @@
 (function () {
 
     let modelFormat
+    let callback
+    let shouldMatchTextureSize = false
+    let toggleMatchTextureSize = new Toggle('match-texture-size', {
+        name: "Match Project UV with Texture Size",
+        default: false,
+        description: "Changes the ProjectUV so that it will always match the size of the active Texture.",
+        onChange(state) {
+            shouldMatchTextureSize = state
+            if (state)
+                updateProjectUV()
+        }
+    })
+    let _width = 0, _height = 0
+    function updateProjectUV() {
+        let texture = UVEditor.texture != 0 ? UVEditor.texture : Texture.selected
+        if (texture != null && (texture.width != _width || texture.height != _height)) {
+            setProjectResolution(1, 1, true)
+            setProjectResolution(texture.width, texture.height, true)
+            _width = texture.width, _height = texture.height
+        }
+    }
 
     BBPlugin.register('figura-format', {
         title: 'Figura Model Format',
@@ -8,11 +29,16 @@
         icon: 'change_history',
         description: 'A custom Model Format for use with the Figura mod, stripping Blockbench features that are incompatible.',
         version: '0.0.1',
-        min_version:'4.7.0',
+        min_version: '4.7.0',
         tags: ['Minecraft: Java Edition', 'Figura'],
         variant: 'both',
         await_loading: true,
         onload() {
+            MenuBar.menus.uv.addAction(toggleMatchTextureSize)
+            callback = Blockbench.on('update_selection', function (data) {
+                if (shouldMatchTextureSize)
+                    updateProjectUV()
+            })
             modelFormat = new ModelFormat('figura', {
                 icon: 'change_history',
                 name: 'Figura',
@@ -53,6 +79,8 @@
             })
         },
         onunload() {
+            MenuBar.menus.uv.removeAction('match-texture')
+            callback.delete()
             modelFormat.delete()
         }
     });


### PR DESCRIPTION
Adds a toggle under the Tools menu that will set the project uv to match the currently active texture, allowing for easier uv editing and texture editing when there are textures with different sizes.
This feature is only available when the uv mode is PerFace. The toggle will not be visible while on box uv.
If while on PerFace and there are individual cubes with BoxUV, they will be switched to perFace before setting the Project UV